### PR TITLE
Update PromptCMS.ai URL Domain

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ client.on("ready", () => {
 
 async function scoreExecution(execution_id: string, affiliate_id: string, score: number) {
   const apiKey = process.env.PROMPTCMS_API_KEY;
-  const apiUrl = 'https://promptcms.ai/api/v1/partner/ai/score';
+  const apiUrl = 'https://www.promptcms.ai/api/v1/partner/ai/score';
 
   const requestData = {
     execution_id: execution_id,


### PR DESCRIPTION
PromptCMS.ai's URL domain will change slightly to avoid relying on CNAME flattening at the root of the domain. This flattening had complicated infrastructural aspects at the application hosting provider.